### PR TITLE
Add a vectorizer for word pieces

### DIFF
--- a/sticker/Cargo.toml
+++ b/sticker/Cargo.toml
@@ -15,5 +15,6 @@ license-file = "../LICENSE.md"
 conllx = "0.12.1"
 failure = "0.1"
 finalfusion = "0.11"
-tch = "0.1"
+numberer = "0.1.1"
+tch = { git = "https://github.com/LaurentMazare/tch-rs.git", rev = "bd9da2d" }
 wordpieces = "0.1"

--- a/sticker/src/input/mod.rs
+++ b/sticker/src/input/mod.rs
@@ -1,6 +1,8 @@
 use conllx::graph::{Node, Sentence};
 use wordpieces::{WordPiece, WordPieces};
 
+pub mod vectorizer;
+
 /// A word piece tokenizer.
 ///
 /// This token splits CoNLL-X tokens into word pieces. For

--- a/sticker/src/input/vectorizer.rs
+++ b/sticker/src/input/vectorizer.rs
@@ -1,0 +1,74 @@
+use std::io::{self, BufRead};
+
+use numberer::Numberer;
+use tch::Tensor;
+
+/// Trait for reading word pieces.
+pub trait ReadWordPieces
+where
+    Self: Sized,
+{
+    /// Read word pieces from a buffered reader.
+    fn read_word_pieces(buf_read: impl BufRead) -> io::Result<Self>;
+}
+
+/// Word word pieces vectorizer.
+pub struct WordPieceVectorizer {
+    numberer: Numberer<String>,
+}
+
+impl WordPieceVectorizer {
+    /// Vectorize a slice of word pieces.
+    pub fn vectorize(&self, word_pieces: &[impl AsRef<str>]) -> Tensor {
+        let indices = word_pieces
+            .iter()
+            .map(|piece| self.numberer.number(piece.as_ref()).expect("Missing piece") as i64)
+            .collect::<Vec<_>>();
+
+        Tensor::of_slice(&indices)
+    }
+}
+
+impl ReadWordPieces for WordPieceVectorizer {
+    fn read_word_pieces(buf_read: impl BufRead) -> io::Result<Self> {
+        let mut numberer = Numberer::new(0);
+
+        for line in buf_read.lines() {
+            let piece = line?;
+            numberer.add(piece);
+        }
+
+        Ok(WordPieceVectorizer { numberer })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    use tch::Tensor;
+
+    use super::{ReadWordPieces, WordPieceVectorizer};
+
+    fn read_vectorizer() -> WordPieceVectorizer {
+        let f = File::open("testdata/bert-base-german-cased-vocab.txt").unwrap();
+        WordPieceVectorizer::read_word_pieces(BufReader::new(f)).unwrap()
+    }
+
+    #[test]
+    fn test_vectorizer() {
+        let vectorizer = read_vectorizer();
+
+        let pieces = &[
+            "Ver", "##unt", "##reute", "die", "A", "##W", "##O", "Spenden", "##geld", "[UNK]",
+        ];
+
+        let tensor = vectorizer.vectorize(pieces);
+
+        assert_eq!(
+            tensor,
+            Tensor::of_slice(&[133i64, 1937, 14010, 30, 32, 26939, 26962, 12558, 2739, 2])
+        );
+    }
+}


### PR DESCRIPTION
This is probably not the final API yet, but putting things in place to the point that we can start experimenting with feeding these to actual PyTorch models.