### PR TITLE
Improvements in the handling of encoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "numberer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-encoders 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tch 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wordpieces 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "sticker-encoders"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -904,7 +904,7 @@ dependencies = [
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker 0.10.0",
- "sticker-encoders 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ dependencies = [
 "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29f1026ef7b2ded56453d708809e15f148b7f5b6a51e1ee0237964881ab85680"
-"checksum sticker-encoders 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ea771b40e739242d66f3b3f5b86b56933c49434615c062f98b68aaf446d6e3b6"
+"checksum sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b18e8f862bc727afdf90b668aa2128a34fceb2f54fd2d340658583fd544588a4"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"

--- a/sticker-utils/src/subcommands/finetune.rs
+++ b/sticker-utils/src/subcommands/finetune.rs
@@ -60,8 +60,12 @@ impl StickerApp for FinetuneApp {
         let encoders: Encoders =
             serde_yaml::from_reader(&f).or_exit("Cannot deserialize labels", 1);
 
-        for encoder_name in encoders.keys() {
-            eprintln!("Loaded labels for encoder '{}'", encoder_name);
+        for encoder in &*encoders {
+            eprintln!(
+                "Loaded labels for encoder '{}': {} labels",
+                encoder.name(),
+                encoder.encoder().len()
+            );
         }
 
         for sentence in treebank_reader.sentences() {

--- a/sticker-utils/src/subcommands/prepare.rs
+++ b/sticker-utils/src/subcommands/prepare.rs
@@ -73,10 +73,11 @@ impl StickerApp for PrepareApp {
         for sentence in treebank_reader.sentences() {
             let sentence = sentence.or_exit("Cannot read sentence from treebank", 1);
 
-            for (name, encoder) in &*encoders {
-                encoder
-                    .encode(&sentence)
-                    .or_exit(format!("Cannot encode sentence with encoder {}", name), 1);
+            for encoder in &*encoders {
+                encoder.encoder().encode(&sentence).or_exit(
+                    format!("Cannot encode sentence with encoder {}", encoder.name()),
+                    1,
+                );
             }
         }
 

--- a/sticker/Cargo.toml
+++ b/sticker/Cargo.toml
@@ -18,7 +18,7 @@ failure = "0.1"
 finalfusion = "0.11"
 numberer = "0.1.1"
 serde = { version = "1", features = [ "derive" ] }
-sticker-encoders = "0.1.2"
+sticker-encoders = "0.1.4"
 tch = "0.1.3"
 toml = "0.5"
 wordpieces = "0.1"

--- a/sticker/src/config.rs
+++ b/sticker/src/config.rs
@@ -92,12 +92,11 @@ fn relativize_path(config_path: &Path, filename: &str) -> Fallible<String> {
 mod tests {
     use std::fs::File;
 
-    use maplit::hashmap;
     use sticker_encoders::layer::Layer;
     use sticker_encoders::lemma::BackoffStrategy;
 
     use crate::config::{Config, Labeler, TomlRead};
-    use crate::encoders::{DependencyEncoder, EncoderType, EncodersConfig};
+    use crate::encoders::{DependencyEncoder, EncoderType, EncodersConfig, NamedEncoderConfig};
 
     #[test]
     fn config() {
@@ -109,12 +108,21 @@ mod tests {
             Config {
                 labeler: Labeler {
                     labels: "sticker.labels".to_string(),
-                    encoders: EncodersConfig(hashmap![
-                    "dep".to_string() => EncoderType::Dependency(DependencyEncoder::RelativePOS),
-                    "lemma".to_string() => EncoderType::Lemma(BackoffStrategy::Form),
-                    "pos".to_string() => EncoderType::Sequence(Layer::Pos),
-                            ]),
-                }
+                    encoders: EncodersConfig(vec![
+                        NamedEncoderConfig {
+                            name: "dep".to_string(),
+                            encoder: EncoderType::Dependency(DependencyEncoder::RelativePOS)
+                        },
+                        NamedEncoderConfig {
+                            name: "lemma".to_string(),
+                            encoder: EncoderType::Lemma(BackoffStrategy::Form)
+                        },
+                        NamedEncoderConfig {
+                            name: "pos".to_string(),
+                            encoder: EncoderType::Sequence(Layer::Pos)
+                        },
+                    ]),
+                },
             }
         );
     }

--- a/sticker/src/encoders/config.rs
+++ b/sticker/src/encoders/config.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
@@ -11,10 +10,10 @@ use sticker_encoders::lemma::BackoffStrategy;
 /// encoder configuration.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct EncodersConfig(pub HashMap<String, EncoderType>);
+pub struct EncodersConfig(pub Vec<NamedEncoderConfig>);
 
 impl Deref for EncodersConfig {
-    type Target = HashMap<String, EncoderType>;
+    type Target = [NamedEncoderConfig];
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -44,4 +43,12 @@ pub enum DependencyEncoder {
 
     /// Encode a token's head by relative position of the POS tag.
     RelativePOS,
+}
+
+/// Configuration of an encoder with a name.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NamedEncoderConfig {
+    pub encoder: EncoderType,
+    pub name: String,
 }

--- a/sticker/src/encoders/encoders.rs
+++ b/sticker/src/encoders/encoders.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::hash::Hash;
 use std::ops::Deref;
 
 use conllx::graph::Sentence;
@@ -6,25 +6,117 @@ use edit_tree::EditTree;
 use failure::Fallible;
 use numberer::Numberer;
 use serde::{Deserialize, Serialize};
-use sticker_encoders::categorical::MutableCategoricalEncoder;
+use sticker_encoders::categorical::{ImmutableCategoricalEncoder, MutableCategoricalEncoder};
 use sticker_encoders::deprel::{
     DependencyEncoding, RelativePOS, RelativePOSEncoder, RelativePosition, RelativePositionEncoder,
 };
 use sticker_encoders::layer::LayerEncoder;
 use sticker_encoders::lemma::EditTreeEncoder;
-use sticker_encoders::SentenceEncoder;
+use sticker_encoders::{EncodingProb, SentenceDecoder, SentenceEncoder};
 
 use crate::encoders::{DependencyEncoder, EncoderType, EncodersConfig};
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CategoricalEncoderWrap<E, V>
+where
+    V: Clone + Eq + Hash,
+{
+    Immutable(ImmutableCategoricalEncoder<E, V>),
+    Mutable(MutableCategoricalEncoder<E, V>),
+}
+
+impl<E, V> From<MutableCategoricalEncoder<E, V>> for CategoricalEncoderWrap<E, V>
+where
+    V: Clone + Eq + Hash,
+{
+    fn from(encoder: MutableCategoricalEncoder<E, V>) -> Self {
+        CategoricalEncoderWrap::Mutable(encoder)
+    }
+}
+
+impl<D> SentenceDecoder for CategoricalEncoderWrap<D, D::Encoding>
+where
+    D: SentenceDecoder,
+    D::Encoding: Clone + Eq + Hash,
+{
+    type Encoding = usize;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Fallible<()>
+    where
+        S: AsRef<[EncodingProb<Self::Encoding>]>,
+    {
+        match self {
+            CategoricalEncoderWrap::Immutable(decoder) => decoder.decode(labels, sentence),
+            CategoricalEncoderWrap::Mutable(decoder) => decoder.decode(labels, sentence),
+        }
+    }
+}
+
+impl<E> SentenceEncoder for CategoricalEncoderWrap<E, E::Encoding>
+where
+    E: SentenceEncoder,
+    E::Encoding: Clone + Eq + Hash,
+{
+    type Encoding = usize;
+
+    fn encode(&self, sentence: &Sentence) -> Fallible<Vec<Self::Encoding>> {
+        match self {
+            CategoricalEncoderWrap::Immutable(encoder) => encoder.encode(sentence),
+            CategoricalEncoderWrap::Mutable(encoder) => encoder.encode(sentence),
+        }
+    }
+}
+
+impl<E, V> CategoricalEncoderWrap<E, V>
+where
+    V: Clone + Eq + Hash,
+{
+    pub fn len(&self) -> usize {
+        match self {
+            CategoricalEncoderWrap::Immutable(encoder) => encoder.len(),
+            CategoricalEncoderWrap::Mutable(encoder) => encoder.len(),
+        }
+    }
+}
 
 /// Wrapper of the various supported encoders.
 #[derive(Deserialize, Serialize)]
 pub enum Encoder {
-    Lemma(MutableCategoricalEncoder<EditTreeEncoder, EditTree<char>>),
-    Layer(MutableCategoricalEncoder<LayerEncoder, String>),
-    RelativePOS(MutableCategoricalEncoder<RelativePOSEncoder, DependencyEncoding<RelativePOS>>),
+    Lemma(CategoricalEncoderWrap<EditTreeEncoder, EditTree<char>>),
+    Layer(CategoricalEncoderWrap<LayerEncoder, String>),
+    RelativePOS(CategoricalEncoderWrap<RelativePOSEncoder, DependencyEncoding<RelativePOS>>),
     RelativePosition(
-        MutableCategoricalEncoder<RelativePositionEncoder, DependencyEncoding<RelativePosition>>,
+        CategoricalEncoderWrap<RelativePositionEncoder, DependencyEncoding<RelativePosition>>,
     ),
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl Encoder {
+    pub fn len(&self) -> usize {
+        match self {
+            Encoder::Layer(encoder) => encoder.len(),
+            Encoder::Lemma(encoder) => encoder.len(),
+            Encoder::RelativePOS(encoder) => encoder.len(),
+            Encoder::RelativePosition(encoder) => encoder.len(),
+        }
+    }
+}
+
+impl SentenceDecoder for Encoder {
+    type Encoding = usize;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Fallible<()>
+    where
+        S: AsRef<[EncodingProb<Self::Encoding>]>,
+    {
+        match self {
+            Encoder::Layer(decoder) => decoder.decode(labels, sentence),
+            Encoder::Lemma(decoder) => decoder.decode(labels, sentence),
+            Encoder::RelativePOS(decoder) => decoder.decode(labels, sentence),
+            Encoder::RelativePosition(decoder) => decoder.decode(labels, sentence),
+        }
+    }
 }
 
 impl SentenceEncoder for Encoder {
@@ -45,45 +137,68 @@ impl From<&EncoderType> for Encoder {
         // We start labeling at 2. 0 is reserved for padding, 1 for continuations.
         match encoder_type {
             EncoderType::Dependency(DependencyEncoder::RelativePOS) => Encoder::RelativePOS(
-                MutableCategoricalEncoder::new(RelativePOSEncoder, Numberer::new(2)),
+                MutableCategoricalEncoder::new(RelativePOSEncoder, Numberer::new(2)).into(),
             ),
             EncoderType::Dependency(DependencyEncoder::RelativePosition) => {
-                Encoder::RelativePosition(MutableCategoricalEncoder::new(
-                    RelativePositionEncoder,
-                    Numberer::new(2),
-                ))
+                Encoder::RelativePosition(
+                    MutableCategoricalEncoder::new(RelativePositionEncoder, Numberer::new(2))
+                        .into(),
+                )
             }
-            EncoderType::Lemma(backoff_strategy) => Encoder::Lemma(MutableCategoricalEncoder::new(
-                EditTreeEncoder::new(*backoff_strategy),
-                Numberer::new(2),
-            )),
-            EncoderType::Sequence(ref layer) => Encoder::Layer(MutableCategoricalEncoder::new(
-                LayerEncoder::new(layer.clone()),
-                Numberer::new(2),
-            )),
+            EncoderType::Lemma(backoff_strategy) => Encoder::Lemma(
+                MutableCategoricalEncoder::new(
+                    EditTreeEncoder::new(*backoff_strategy),
+                    Numberer::new(2),
+                )
+                .into(),
+            ),
+            EncoderType::Sequence(ref layer) => Encoder::Layer(
+                MutableCategoricalEncoder::new(LayerEncoder::new(layer.clone()), Numberer::new(2))
+                    .into(),
+            ),
         }
     }
 }
 
-/// A set of encoders
-///
-/// This set is a mapping from encoder names to encoders.
+/// A named encoder.
+#[derive(Deserialize, Serialize)]
+pub struct NamedEncoder {
+    encoder: Encoder,
+    name: String,
+}
+
+impl NamedEncoder {
+    /// Get the encoder.
+    pub fn encoder(&self) -> &Encoder {
+        &self.encoder
+    }
+
+    /// Get the encoder name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A collection of named encoders.
 #[derive(Serialize, Deserialize)]
-pub struct Encoders(HashMap<String, Encoder>);
+pub struct Encoders(Vec<NamedEncoder>);
 
 impl From<&EncodersConfig> for Encoders {
     fn from(config: &EncodersConfig) -> Self {
         Encoders(
             config
                 .iter()
-                .map(|(name, encoder_type)| (name.clone(), encoder_type.into()))
+                .map(|encoder| NamedEncoder {
+                    name: encoder.name.clone(),
+                    encoder: (&encoder.encoder).into(),
+                })
                 .collect(),
         )
     }
 }
 
 impl Deref for Encoders {
-    type Target = HashMap<String, Encoder>;
+    type Target = [NamedEncoder];
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/sticker/src/encoders/mod.rs
+++ b/sticker/src/encoders/mod.rs
@@ -1,8 +1,8 @@
 //! Encoder configuration and construction.
 
 mod config;
-pub use config::{DependencyEncoder, EncoderType, EncodersConfig};
+pub use config::{DependencyEncoder, EncoderType, EncodersConfig, NamedEncoderConfig};
 
 #[allow(clippy::module_inception)]
 mod encoders;
-pub use encoders::{Encoder, Encoders};
+pub use encoders::{Encoder, Encoders, NamedEncoder};

--- a/sticker/testdata/sticker.conf
+++ b/sticker/testdata/sticker.conf
@@ -1,7 +1,7 @@
 [labeler]
 labels = "sticker.labels"
-
-[labeler.encoders]
-dep = { dependency = "relativepos" }
-lemma = { lemma = "form" }
-pos = { sequence = "pos" }
+encoders = [
+  { name = "dep", encoder = { dependency = "relativepos" } },
+  { name = "lemma", encoder = { lemma = "form" } },
+  { name = "pos", encoder = { sequence = "pos" } },
+]


### PR DESCRIPTION
- The encoder configuration changes from using a HashMap to a
  Vec. This allows for ordering of encoders, which is sometimes
  necessary (e.g. POS tag decoding before dependency decoding).

  Since we still want to be able to name encoders, the NamedEncoder
  struct is introduced.

- Introduce the CategoricalEncoderWrap, wrapping mutable and
  immutable flavors of categorical encoders. Deserialization will
  always deserialize into an immutable categorical encoder.

- Add the len method to query the 'length' of encoders.