### PR TITLE
TensorBuilder: always build up token mask tensor

### DIFF
--- a/sticker/src/tagger/mod.rs
+++ b/sticker/src/tagger/mod.rs
@@ -84,7 +84,7 @@ impl Tagger {
                 token_mask[*token_idx] = 1;
             }
 
-            builder.add_without_labels(input.view());
+            builder.add_without_labels(input.view(), token_mask.view());
         }
 
         Ok(builder.into())


### PR DESCRIPTION
The token mask may be necessary, even when the data does not have
labels, such as in model distillation scenarios.