### PR TITLE
Place labels on the correct device

### DIFF
--- a/sticker-utils/src/subcommands/finetune.rs
+++ b/sticker-utils/src/subcommands/finetune.rs
@@ -162,7 +162,12 @@ impl FinetuneApp {
                 &batch.inputs.to_device(self.device),
                 &attention_mask.to_device(self.device),
                 &batch.token_mask.to_device(self.device),
-                &batch.labels.expect("Batch without labels."),
+                &batch
+                    .labels
+                    .expect("Batch without labels.")
+                    .into_iter()
+                    .map(|(encoder_name, labels)| (encoder_name, labels.to_device(self.device)))
+                    .collect(),
                 self.label_smoothing,
                 optimizer.is_some(),
                 !self.finetune_embeds || freeze_encoder,


### PR DESCRIPTION
The labels were always placed on the CPU. This error was introduced
when cleaning up commits for PRs.