### PR TITLE
Update to sticker-transformers 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-transformers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-transformers 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tch 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wordpieces 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "sticker-transformers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1033,7 +1033,7 @@ dependencies = [
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker 0.10.0",
  "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-transformers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-transformers 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tch 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1362,7 +1362,7 @@ dependencies = [
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29f1026ef7b2ded56453d708809e15f148b7f5b6a51e1ee0237964881ab85680"
 "checksum sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b18e8f862bc727afdf90b668aa2128a34fceb2f54fd2d340658583fd544588a4"
-"checksum sticker-transformers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3135bb5f8b807d3eab045ec3fbac99aece1e60061280358dae7065bc992c2"
+"checksum sticker-transformers 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2baee53c0d5f81087f3cfc5a4aeed06818369c60aa9e84a8a56b357ed291478e"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"

--- a/sticker-utils/Cargo.toml
+++ b/sticker-utils/Cargo.toml
@@ -18,6 +18,6 @@ serde_yaml = "0.8"
 stdinout = "0.4"
 sticker = { path = "../sticker" }
 sticker-encoders = "0.1.4"
-sticker-transformers = "0.1"
+sticker-transformers = "0.2"
 tch = "0.1.3"
 threadpool = "1"

--- a/sticker-utils/src/io.rs
+++ b/sticker-utils/src/io.rs
@@ -6,7 +6,7 @@ use sticker::encoders::Encoders;
 use sticker::input::vectorizer::WordPieceVectorizer;
 use sticker::input::WordPieceTokenizer;
 use sticker::model::BertModel;
-use sticker_transformers::bert_model::BertConfig;
+use sticker_transformers::models::bert::BertConfig;
 use tch::nn::VarStore;
 use tch::Device;
 

--- a/sticker/Cargo.toml
+++ b/sticker/Cargo.toml
@@ -23,7 +23,7 @@ rand_xorshift = "0.2"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sticker-encoders = "0.1.4"
-sticker-transformers = "0.1"
+sticker-transformers = "0.2"
 tch = "0.1.3"
 toml = "0.5"
 wordpieces = "0.1.1"

--- a/sticker/src/config.rs
+++ b/sticker/src/config.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use failure::{format_err, Fallible};
 use serde::{Deserialize, Serialize};
 use serde_json;
-use sticker_transformers::bert_model::BertConfig;
+use sticker_transformers::models::bert::BertConfig;
 use toml;
 use wordpieces::WordPieces;
 


### PR DESCRIPTION
This also adds non-linear transformation of scalar weighting
output. This breaks compatibility with previous models