### PR TITLE
Remove the --input and --output options

### DIFF
--- a/sticker2-utils/src/subcommands/annotate.rs
+++ b/sticker2-utils/src/subcommands/annotate.rs
@@ -69,16 +69,11 @@ impl StickerApp for AnnotateApp {
                     .index(1)
                     .required(true),
             )
-            .arg(
-                Arg::with_name(INPUT)
-                    .help("Input data")
-                    .long("input")
-                    .takes_value(true),
-            )
+            .arg(Arg::with_name(INPUT).help("Input data").index(2))
             .arg(
                 Arg::with_name(OUTPUT)
                     .help("Output data")
-                    .long("output")
+                    .index(3)
                     .takes_value(true),
             )
             .arg(


### PR DESCRIPTION
Instead, just take the input and output as arguments. So:

sticker-annotate sticker.conf --input foo.conll --output bar.conll

becomes:

sticker-annotate sticker.conf foo.conll bar.conll

The options were a remnant of sticker1, where we take an arbitrary
number of configuration file to form a pipeline.