### PR TITLE
Abstract over tokenizer implementations with the Tokenize trait

### DIFF
--- a/sticker2-utils/src/io.rs
+++ b/sticker2-utils/src/io.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use stdinout::OrExit;
 use sticker2::config::{Config, TomlRead};
 use sticker2::encoders::Encoders;
-use sticker2::input::WordPieceTokenizer;
+use sticker2::input::Tokenize;
 use sticker2::model::BertModel;
 use sticker_transformers::models::bert::BertConfig;
 use tch::nn::VarStore;
@@ -13,7 +13,7 @@ use tch::Device;
 pub struct Model {
     pub encoders: Encoders,
     pub model: BertModel,
-    pub tokenizer: WordPieceTokenizer,
+    pub tokenizer: Box<dyn Tokenize>,
     pub vs: VarStore,
 }
 
@@ -139,9 +139,11 @@ fn load_encoders(config: &Config) -> Encoders {
     encoders
 }
 
-fn load_tokenizer(config: &Config) -> WordPieceTokenizer {
-    config
-        .input
-        .word_piece_tokenizer()
-        .or_exit("Cannot read word pieces", 1)
+fn load_tokenizer(config: &Config) -> Box<dyn Tokenize> {
+    Box::new(
+        config
+            .input
+            .word_piece_tokenizer()
+            .or_exit("Cannot read word pieces", 1),
+    )
 }

--- a/sticker2-utils/src/sent_proc.rs
+++ b/sticker2-utils/src/sent_proc.rs
@@ -2,14 +2,14 @@ use conllx::graph::Sentence;
 use conllx::io::WriteSentence;
 use failure::Fallible;
 
-use sticker2::input::{SentenceWithPieces, Tokenize, WordPieceTokenizer};
+use sticker2::input::{SentenceWithPieces, Tokenize};
 use sticker2::tagger::Tagger;
 
 pub struct SentProcessor<'a, W>
 where
     W: WriteSentence,
 {
-    tokenizer: &'a WordPieceTokenizer,
+    tokenizer: &'a dyn Tokenize,
     tagger: &'a Tagger,
     writer: W,
     batch_size: usize,
@@ -32,7 +32,7 @@ where
     /// process sentences. This read-ahead is used to sort sentences
     /// by length to speed up processing.
     pub fn new(
-        tokenizer: &'a WordPieceTokenizer,
+        tokenizer: &'a dyn Tokenize,
         tagger: &'a Tagger,
         writer: W,
         batch_size: usize,
@@ -55,7 +55,7 @@ where
 
     /// Process a sentence.
     pub fn process(&mut self, sent: Sentence) -> Fallible<()> {
-        let tokenized_sentence = sent.tokenize(&self.tokenizer);
+        let tokenized_sentence = self.tokenizer.tokenize(sent);
 
         if let Some(max_len) = self.max_len {
             // sent.len() includes the root node, whereas max_len is

--- a/sticker2-utils/src/subcommands/annotate.rs
+++ b/sticker2-utils/src/subcommands/annotate.rs
@@ -3,7 +3,7 @@ use std::io::BufWriter;
 use clap::{App, Arg, ArgMatches};
 use conllx::io::{ReadSentence, Reader, WriteSentence, Writer};
 use stdinout::{Input, OrExit, Output};
-use sticker2::input::WordPieceTokenizer;
+use sticker2::input::Tokenize;
 use sticker2::tagger::Tagger;
 use tch::{self, Device};
 
@@ -31,7 +31,7 @@ pub struct AnnotateApp {
 }
 
 impl AnnotateApp {
-    fn process<R, W>(&self, tokenizer: &WordPieceTokenizer, tagger: Tagger, read: R, write: W)
+    fn process<R, W>(&self, tokenizer: &dyn Tokenize, tagger: Tagger, read: R, write: W)
     where
         R: ReadSentence,
         W: WriteSentence,
@@ -39,7 +39,7 @@ impl AnnotateApp {
         let mut speed = TaggerSpeed::new();
 
         let mut sent_proc = SentProcessor::new(
-            &tokenizer,
+            tokenizer,
             &tagger,
             write,
             self.batch_size,
@@ -152,6 +152,6 @@ impl StickerApp for AnnotateApp {
             output.write().or_exit("Cannot open output for writing", 1),
         ));
 
-        self.process(&model.tokenizer, tagger, reader, writer)
+        self.process(&*model.tokenizer, tagger, reader, writer)
     }
 }

--- a/sticker2-utils/src/subcommands/distill.rs
+++ b/sticker2-utils/src/subcommands/distill.rs
@@ -12,7 +12,7 @@ use stdinout::OrExit;
 use sticker2::config::Config;
 use sticker2::dataset::{ConllxDataSet, DataSet};
 use sticker2::encoders::Encoders;
-use sticker2::input::WordPieceTokenizer;
+use sticker2::input::Tokenize;
 use sticker2::lr::{ExponentialDecay, LearningRateSchedule};
 use sticker2::model::BertModel;
 use sticker2::optimizers::{AdamW, AdamWConfig};
@@ -98,7 +98,7 @@ impl DistillApp {
 
             let train_batches = train_dataset.batches(
                 &teacher.encoders,
-                &teacher.tokenizer,
+                &*teacher.tokenizer,
                 self.batch_size,
                 self.max_len,
                 None,
@@ -118,7 +118,7 @@ impl DistillApp {
                 let acc = tch::no_grad(|| {
                     self.validation_epoch(
                         &teacher.encoders,
-                        &teacher.tokenizer,
+                        &*teacher.tokenizer,
                         &student.inner,
                         validation_file,
                         global_step,
@@ -332,7 +332,7 @@ impl DistillApp {
     fn validation_epoch(
         &self,
         encoders: &Encoders,
-        tokenizer: &WordPieceTokenizer,
+        tokenizer: &dyn Tokenize,
         model: &BertModel,
         file: &mut File,
         global_step: usize,

--- a/sticker2-utils/src/subcommands/finetune.rs
+++ b/sticker2-utils/src/subcommands/finetune.rs
@@ -8,7 +8,7 @@ use ordered_float::NotNan;
 use stdinout::OrExit;
 use sticker2::dataset::{ConllxDataSet, DataSet};
 use sticker2::encoders::Encoders;
-use sticker2::input::WordPieceTokenizer;
+use sticker2::input::Tokenize;
 use sticker2::lr::{ExponentialDecay, LearningRateSchedule, PlateauLearningRate};
 use sticker2::model::BertModel;
 use sticker2::optimizers::{AdamW, AdamWConfig};
@@ -101,7 +101,7 @@ impl FinetuneApp {
     fn run_epoch(
         &self,
         encoders: &Encoders,
-        tokenizer: &WordPieceTokenizer,
+        tokenizer: &dyn Tokenize,
         model: &BertModel,
         file: &mut File,
         mut optimizer: Option<&mut AdamW>,
@@ -507,7 +507,7 @@ impl StickerApp for FinetuneApp {
 
             self.run_epoch(
                 &model.encoders,
-                &model.tokenizer,
+                &*model.tokenizer,
                 &model.model,
                 &mut train_file,
                 Some(&mut opt),
@@ -520,7 +520,7 @@ impl StickerApp for FinetuneApp {
             last_acc = tch::no_grad(|| {
                 self.run_epoch(
                     &model.encoders,
-                    &model.tokenizer,
+                    &*model.tokenizer,
                     &model.model,
                     &mut validation_file,
                     None,

--- a/sticker2/src/config.rs
+++ b/sticker2/src/config.rs
@@ -11,7 +11,7 @@ use toml;
 use wordpieces::WordPieces;
 
 use crate::encoders::EncodersConfig;
-use crate::input::WordPieceTokenizer;
+use crate::input::BertTokenizer;
 
 /// Input configuration.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -23,10 +23,10 @@ pub struct Input {
 
 impl Input {
     /// Construct a word piece tokenizer.
-    pub fn word_piece_tokenizer(&self) -> Fallible<WordPieceTokenizer> {
+    pub fn word_piece_tokenizer(&self) -> Fallible<BertTokenizer> {
         let f = File::open(&self.word_pieces)?;
         let pieces = WordPieces::try_from(BufReader::new(f).lines())?;
-        Ok(WordPieceTokenizer::new(pieces, "[UNK]"))
+        Ok(BertTokenizer::new(pieces, "[UNK]"))
     }
 }
 

--- a/sticker2/src/input/bert.rs
+++ b/sticker2/src/input/bert.rs
@@ -1,0 +1,106 @@
+use conllx::graph::{Node, Sentence};
+use wordpieces::WordPieces;
+
+use crate::input::{SentenceWithPieces, Tokenize};
+
+/// BERT word piece tokenizer.
+///
+/// This tokenizer splits CoNLL-X tokens into word pieces. For
+/// example, a sentence such as:
+///
+/// > Veruntreute die AWO Spendengeld ?
+///
+/// Could be split (depending on the vocabulary) into the following
+/// word pieces:
+///
+/// > Ver ##unt ##reute die A ##W ##O Spenden ##geld [UNK]
+///
+/// Then vocabulary index of each such piece is returned.
+///
+/// The unknown token (here `[UNK]`) can be specified while
+/// constructing a tokenizer.
+pub struct BertTokenizer {
+    word_pieces: WordPieces,
+    unknown_piece: String,
+}
+
+impl BertTokenizer {
+    /// Construct a tokenizer from wordpieces and the unknown piece.
+    pub fn new(word_pieces: WordPieces, unknown_piece: impl Into<String>) -> Self {
+        BertTokenizer {
+            word_pieces,
+            unknown_piece: unknown_piece.into(),
+        }
+    }
+}
+
+impl Tokenize for BertTokenizer {
+    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces {
+        // An average of three pieces per token ought to enough for
+        // everyone ;).
+        let mut pieces = Vec::with_capacity((sentence.len() - 1) * 3);
+        let mut token_offsets = Vec::with_capacity(sentence.len());
+
+        for token in sentence.iter().filter_map(Node::token) {
+            token_offsets.push(pieces.len());
+
+            match self
+                .word_pieces
+                .split(token.form())
+                .map(|piece| piece.idx().map(|piece| piece as i64))
+                .collect::<Option<Vec<_>>>()
+            {
+                Some(word_pieces) => pieces.extend(word_pieces),
+                None => pieces.push(
+                    self.word_pieces
+                        .get_initial(&self.unknown_piece)
+                        .expect("Cannot get unknown piece") as i64,
+                ),
+            }
+        }
+
+        SentenceWithPieces {
+            pieces: pieces.into(),
+            sentence,
+            token_offsets,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+    use std::iter::FromIterator;
+
+    use conllx::graph::Sentence;
+    use conllx::token::Token;
+    use ndarray::array;
+    use wordpieces::WordPieces;
+
+    use crate::input::{BertTokenizer, Tokenize};
+
+    fn read_pieces() -> WordPieces {
+        let f = File::open("testdata/bert-base-german-cased-vocab.txt").unwrap();
+        WordPieces::try_from(BufReader::new(f).lines()).unwrap()
+    }
+
+    fn sentence_from_forms(forms: &[&str]) -> Sentence {
+        Sentence::from_iter(forms.iter().map(|&f| Token::new(f)))
+    }
+
+    #[test]
+    fn test_pieces() {
+        let tokenizer = BertTokenizer::new(read_pieces(), "[UNK]");
+
+        let sentence = sentence_from_forms(&["Veruntreute", "die", "AWO", "Spendengeld", "?"]);
+
+        let sentence_pieces = tokenizer.tokenize(sentence);
+        assert_eq!(
+            sentence_pieces.pieces,
+            array![133i64, 1937, 14010, 30, 32, 26939, 26962, 12558, 2739, 2]
+        );
+        assert_eq!(sentence_pieces.token_offsets, &[0, 3, 4, 7, 9]);
+    }
+}

--- a/sticker2/src/input/mod.rs
+++ b/sticker2/src/input/mod.rs
@@ -1,17 +1,13 @@
-use conllx::graph::{Node, Sentence};
+use conllx::graph::Sentence;
 use ndarray::Array1;
-use wordpieces::WordPieces;
+
+mod bert;
+pub use bert::BertTokenizer;
 
 /// Trait for wordpiece tokenizers.
-pub trait Tokenize {
+pub trait Tokenize: Send + Sync {
     /// Tokenize the tokens in a sentence into word pieces.
-    fn tokenize(self, tokenizer: &WordPieceTokenizer) -> SentenceWithPieces;
-}
-
-impl Tokenize for Sentence {
-    fn tokenize(self, tokenizer: &WordPieceTokenizer) -> SentenceWithPieces {
-        tokenizer.tokenize(self)
-    }
+    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces;
 }
 
 /// A sentence and its word pieces.
@@ -24,111 +20,4 @@ pub struct SentenceWithPieces {
 
     /// The the offsets of tokens in `pieces`.
     pub token_offsets: Vec<usize>,
-}
-
-/// A word piece tokenizer.
-///
-/// This token splits CoNLL-X tokens into word pieces. For
-/// example, a sentence such as:
-///
-/// > Veruntreute die AWO Spendengeld ?
-///
-/// Could be split (depending on the vocabulary) into the following
-/// word pieces:
-///
-/// > Ver ##unt ##reute die A ##W ##O Spenden ##geld [UNK]
-///
-/// The unknown token (here `[UNK]`) can be specified while
-/// constructing a tokenizer.
-pub struct WordPieceTokenizer {
-    word_pieces: WordPieces,
-    unknown_piece: String,
-}
-
-impl WordPieceTokenizer {
-    /// Construct a tokenizer from wordpieces and the unknown piece.
-    pub fn new(word_pieces: WordPieces, unknown_piece: impl Into<String>) -> Self {
-        WordPieceTokenizer {
-            word_pieces,
-            unknown_piece: unknown_piece.into(),
-        }
-    }
-
-    /// Tokenize a CoNLL-X sentence.
-    ///
-    /// Returns a pair of:
-    ///
-    /// * The word pieces of all tokens;
-    /// * the offset of each token into the word pieces.
-    ///
-    /// The offset at position 0 represents the first word (and not the
-    /// special *ROOT* token).
-    pub fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces {
-        // An average of three pieces per token ought to enough for
-        // everyone ;).
-        let mut pieces = Vec::with_capacity((sentence.len() - 1) * 3);
-        let mut token_offsets = Vec::with_capacity(sentence.len());
-
-        for token in sentence.iter().filter_map(Node::token) {
-            token_offsets.push(pieces.len());
-
-            match self
-                .word_pieces
-                .split(token.form())
-                .map(|piece| piece.idx().map(|piece| piece as i64))
-                .collect::<Option<Vec<_>>>()
-            {
-                Some(word_pieces) => pieces.extend(word_pieces),
-                None => pieces.push(
-                    self.word_pieces
-                        .get_initial(&self.unknown_piece)
-                        .expect("Cannot get unknown piece") as i64,
-                ),
-            }
-        }
-
-        SentenceWithPieces {
-            pieces: pieces.into(),
-            sentence,
-            token_offsets,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::convert::TryFrom;
-    use std::fs::File;
-    use std::io::{BufRead, BufReader};
-    use std::iter::FromIterator;
-
-    use conllx::graph::Sentence;
-    use conllx::token::Token;
-    use ndarray::array;
-    use wordpieces::WordPieces;
-
-    use super::WordPieceTokenizer;
-
-    fn read_pieces() -> WordPieces {
-        let f = File::open("testdata/bert-base-german-cased-vocab.txt").unwrap();
-        WordPieces::try_from(BufReader::new(f).lines()).unwrap()
-    }
-
-    fn sentence_from_forms(forms: &[&str]) -> Sentence {
-        Sentence::from_iter(forms.iter().map(|&f| Token::new(f)))
-    }
-
-    #[test]
-    fn test_pieces() {
-        let tokenizer = WordPieceTokenizer::new(read_pieces(), "[UNK]");
-
-        let sentence = sentence_from_forms(&["Veruntreute", "die", "AWO", "Spendengeld", "?"]);
-
-        let sentence_pieces = tokenizer.tokenize(sentence);
-        assert_eq!(
-            sentence_pieces.pieces,
-            array![133i64, 1937, 14010, 30, 32, 26939, 26962, 12558, 2739, 2]
-        );
-        assert_eq!(sentence_pieces.token_offsets, &[0, 3, 4, 7, 9]);
-    }
 }


### PR DESCRIPTION
- WordPieceTokenizer is renamed to BertTokenizer
- The Tokenize trait is now implemented on tokenizers rather than
  Sentence.
- Use the Tokenize trait throughout the project rather a specific
  tokenizer.