### PR TITLE
Add a tokenizer for XLM-RoBERTa models

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,21 +18,3 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install libhdf5
-        run: sudo apt-get install libhdf5-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +671,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -904,6 +919,28 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sentencepiece"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentencepiece-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentencepiece-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "seqalign"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1048,7 @@ dependencies = [
  "numberer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentencepiece 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1307,6 +1345,7 @@ dependencies = [
 "checksum ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf380a8af901ad627594013a3bbac903ae0a6f94e176e47e46b5bbc1877b928"
 "checksum ndarray 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25b001fc2f5df269365fb77bd8396ce6b1f61c9848f7f088c25e57494bacc57b"
 "checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
+"checksum num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
 "checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
@@ -1324,6 +1363,7 @@ dependencies = [
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6686ddd96a8dbe2687b5f2a687b2cfb520854010ec480f2d74c32e7c9873d3c5"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -1354,6 +1394,8 @@ dependencies = [
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum sentencepiece 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b1927eca22d5dfa2062f80927857da0f54747eef634a55be288dc8039d417dd"
+"checksum sentencepiece-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a22763cf54ad9a97161d0f0695e01d3cc2cdd4bdf5826827db1f42fda48b5e1e"
 "checksum seqalign 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bca394e52155b436797ed84651ce1d036102480d06048e0a187d76b5bbe49a62"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"

--- a/nix/Cargo.nix
+++ b/nix/Cargo.nix
@@ -1662,6 +1662,35 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" ];
       };
+    "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "num-derive";
+        version = "0.3.0";
+        edition = "2018";
+        sha256 = "0imprwv8cs01k46g56ajlvc97dp8kz51y2vn6cp9jkw1c6r1b2qc";
+        procMacro = true;
+        libName = "num_derive";
+        authors = [
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "quote";
+            packageId = "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "syn";
+            packageId = "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        features = {
+          "full-syntax" = [ "syn/full" ];
+        };
+      };
     "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "num-integer";
@@ -2058,6 +2087,20 @@ rec {
           "default" = [ "proc-macro" ];
         };
         resolvedDefaultFeatures = [ "default" "proc-macro" ];
+      };
+    "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "protobuf";
+        version = "2.10.1";
+        edition = "2015";
+        sha256 = "1ifkffc7qbn3fhnhyj7c2108a85mryr8g9pjnn3jdglddbcxv1k6";
+        authors = [
+          "Stepan Koltsov <stepan.koltsov@gmail.com>"
+        ];
+        features = {
+          "with-bytes" = [ "bytes" ];
+          "with-serde" = [ "serde" "serde_derive" ];
+        };
       };
     "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
@@ -2789,6 +2832,67 @@ rec {
         features = {
         };
       };
+    "sentencepiece 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "sentencepiece";
+        version = "0.1.2";
+        edition = "2018";
+        sha256 = "1p8pshwq1p48w9dsad7nxr3lgxd0gn2jf2gqc8hglp9dlbn2f69b";
+        authors = [
+          "Daniël de Kok <me@danieldk.eu>"
+        ];
+        dependencies = [
+          {
+            name = "failure";
+            packageId = "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "libc";
+            packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "num-derive";
+            packageId = "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "num-traits";
+            packageId = "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "protobuf";
+            packageId = "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "sentencepiece-sys";
+            packageId = "sentencepiece-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        features = {
+          "proto-compile" = [ "protoc-rust" ];
+        };
+      };
+    "sentencepiece-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "sentencepiece-sys";
+        version = "0.1.2";
+        edition = "2018";
+        sha256 = "07jyifjgshhzvckni0pmppacvhiw3ph9a1hg3lb9g6mdak7n69x2";
+        authors = [
+          "Daniël de Kok <me@danieldk.eu>"
+        ];
+        buildDependencies = [
+          {
+            name = "cc";
+            packageId = "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "pkg-config";
+            packageId = "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        features = {
+        };
+      };
     "seqalign 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "seqalign";
@@ -3105,6 +3209,10 @@ rec {
           {
             name = "rand_xorshift";
             packageId = "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "sentencepiece";
+            packageId = "sentencepiece 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
           }
           {
             name = "serde";

--- a/nix/models.nix
+++ b/nix/models.nix
@@ -1,0 +1,7 @@
+let
+  sources = import ./sources.nix;
+in {
+  # Vocabularies for testing.
+  BERT_BASE_GERMAN_CASED_VOCAB = sources.bert-base-german-cased-vocab;
+  XLM_ROBERTA_BASE_SENTENCEPIECE = sources.xlm-roberta-base-sentencepiece;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,5 +53,12 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/73c51e064a9a730ebba9518d960755d287a86035.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "xlm-roberta-base-sentencepiece": {
+        "sha256": "0r98vghgqykj19d19jly0nmi2z1gjpknvid0wblqh11aprm19j6g",
+        "type": "file",
+        "url": "https://s3.amazonaws.com/models.huggingface.co/bert/xlm-roberta-base-sentencepiece.bpe.model",
+        "url_template": "https://s3.amazonaws.com/models.huggingface.co/bert/xlm-roberta-base-sentencepiece.bpe.model",
+        "version": "1"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,7 @@
 
 let
   sources = import ./nix/sources.nix;
+  models = import ./nix/models.nix;
   nixpkgs = import sources.nixpkgs {};
   danieldk = nixpkgs.callPackage sources.danieldk {};
   mozilla = nixpkgs.callPackage "${sources.mozilla}/package-set.nix" {};
@@ -10,7 +11,8 @@ let
   # PyTorch 1.4.0 headers are not compatible with gcc 9. Remove with
   # the next PyTorch release.
   stdenv = if nixpkgs.stdenv.cc.isGNU then nixpkgs.gcc8Stdenv else nixpkgs.stdenv;
-in with nixpkgs; mkShell.override (attr: { inherit stdenv; }) {
+  mkShell = nixpkgs.mkShell.override (attr: { inherit stdenv; });
+in with nixpkgs; mkShell (models // {
   nativeBuildInputs = [
     mozilla.latest.rustChannels.stable.rust
     pkgconfig
@@ -19,13 +21,11 @@ in with nixpkgs; mkShell.override (attr: { inherit stdenv; }) {
   buildInputs = [
     curl
     openssl
+    (sentencepiece.override (attrs: { inherit stdenv; }))
   ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
   # Unless we use pkg-config, the hdf5-sys build script does not like
   # it if libraries and includes are in different directories.
   HDF5_DIR = symlinkJoin { name = "hdf5-join"; paths = [ hdf5.dev hdf5.out ]; };
 
   LIBTORCH = "${danieldk.libtorch.v1_4_0}";
-
-  # Vocabularies for testing.
-  BERT_BASE_GERMAN_CASED_VOCAB = sources.bert-base-german-cased-vocab;
-}
+})

--- a/sticker2-utils/src/io.rs
+++ b/sticker2-utils/src/io.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
 use stdinout::OrExit;
-use sticker2::config::{Config, TomlRead};
+use sticker2::config::{Config, PretrainConfig, TomlRead};
 use sticker2::encoders::Encoders;
 use sticker2::input::Tokenize;
 use sticker2::model::BertModel;
@@ -97,11 +97,15 @@ impl Model {
     }
 }
 
-fn load_bert_config(config: &Config) -> BertConfig {
-    config
+pub fn load_bert_config(config: &Config) -> BertConfig {
+    match config
         .model
         .pretrain_config()
         .or_exit("Cannot load pretraining model configuration", 1)
+    {
+        PretrainConfig::Bert(config) => config,
+        PretrainConfig::XlmRoberta(config) => config,
+    }
 }
 
 pub fn load_config(config_path: &str) -> Config {
@@ -140,10 +144,7 @@ fn load_encoders(config: &Config) -> Encoders {
 }
 
 fn load_tokenizer(config: &Config) -> Box<dyn Tokenize> {
-    Box::new(
-        config
-            .input
-            .word_piece_tokenizer()
-            .or_exit("Cannot read word pieces", 1),
-    )
+    config
+        .tokenizer()
+        .or_exit("Cannot read tokenizer vocabulary", 1)
 }

--- a/sticker2-utils/src/subcommands/distill.rs
+++ b/sticker2-utils/src/subcommands/distill.rs
@@ -21,7 +21,7 @@ use sticker2::util::seq_len_to_mask;
 use tch::nn::VarStore;
 use tch::{self, Device, Kind, Reduction, Tensor};
 
-use crate::io::{load_config, Model};
+use crate::io::{load_bert_config, load_config, Model};
 use crate::progress::ReadProgress;
 use crate::traits::{StickerApp, DEFAULT_CLAP_SETTINGS};
 use crate::util::count_conllx_sentences;
@@ -286,10 +286,7 @@ impl DistillApp {
     }
 
     fn fresh_student(&self, student_config: &Config, teacher: &Model) -> StudentModel {
-        let bert_config = student_config
-            .model
-            .pretrain_config()
-            .or_exit("Cannot load pretraining model configuration", 1);
+        let bert_config = load_bert_config(student_config);
 
         let vs = VarStore::new(self.device);
 

--- a/sticker2/Cargo.toml
+++ b/sticker2/Cargo.toml
@@ -20,6 +20,7 @@ ndarray = "0.13"
 numberer = "0.1.1"
 rand = "0.7"
 rand_xorshift = "0.2"
+sentencepiece = "0.1.2"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sticker-encoders = "0.1.4"

--- a/sticker2/src/input/mod.rs
+++ b/sticker2/src/input/mod.rs
@@ -4,6 +4,9 @@ use ndarray::Array1;
 mod bert;
 pub use bert::BertTokenizer;
 
+mod xlm_roberta;
+pub use xlm_roberta::XlmRobertaTokenizer;
+
 /// Trait for wordpiece tokenizers.
 pub trait Tokenize: Send + Sync {
     /// Tokenize the tokens in a sentence into word pieces.

--- a/sticker2/src/input/xlm_roberta.rs
+++ b/sticker2/src/input/xlm_roberta.rs
@@ -1,0 +1,95 @@
+use conllx::graph::{Node, Sentence};
+use sentencepiece::SentencePieceProcessor;
+
+use crate::input::{SentenceWithPieces, Tokenize};
+
+const FAIRSEQ_BOS_ID: i64 = 0;
+const FAIRSEQ_EOS_ID: i64 = 2;
+const FAIRSEQ_OFFSET: i64 = 1;
+
+/// Tokenizer for Roberta models.
+///
+/// Roberta uses the sentencepiece tokenizer. However, we cannot use
+/// it in the intended way: we would have to detokenize sentences and
+/// it is not guaranteed that each token has a unique piece, which is
+/// required in sequence labeling. So instead, we use the tokenizer as
+/// a subword tokenizer.
+pub struct XlmRobertaTokenizer {
+    spp: SentencePieceProcessor,
+}
+
+impl XlmRobertaTokenizer {
+    pub fn new(spp: SentencePieceProcessor) -> Self {
+        XlmRobertaTokenizer { spp }
+    }
+}
+
+impl From<SentencePieceProcessor> for XlmRobertaTokenizer {
+    fn from(spp: SentencePieceProcessor) -> Self {
+        XlmRobertaTokenizer::new(spp)
+    }
+}
+
+impl Tokenize for XlmRobertaTokenizer {
+    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces {
+        // An average of three pieces per token ought to be enough for
+        // everyone ;).
+        let mut pieces = Vec::with_capacity((sentence.len() - 1) * 3);
+        let mut token_offsets = Vec::with_capacity(sentence.len());
+
+        pieces.push(FAIRSEQ_BOS_ID);
+
+        for token in sentence.iter().filter_map(Node::token) {
+            token_offsets.push(pieces.len());
+
+            pieces.extend(
+                self.spp
+                    .encode(token.form())
+                    .expect("The sentencepiece tokenizer failed")
+                    .iter()
+                    .map(|piece| piece.id as i64 + FAIRSEQ_OFFSET),
+            );
+        }
+
+        pieces.push(FAIRSEQ_EOS_ID);
+
+        SentenceWithPieces {
+            pieces: pieces.into(),
+            sentence,
+            token_offsets,
+        }
+    }
+}
+
+#[cfg(feature = "model-tests")]
+#[cfg(test)]
+mod tests {
+    use std::iter::FromIterator;
+
+    use conllx::graph::Sentence;
+    use conllx::token::Token;
+    use ndarray::array;
+    use sentencepiece::SentencePieceProcessor;
+
+    use crate::input::{Tokenize, XlmRobertaTokenizer};
+
+    fn sentence_from_forms(forms: &[&str]) -> Sentence {
+        Sentence::from_iter(forms.iter().map(|&f| Token::new(f)))
+    }
+
+    fn xlm_roberta_tokenizer() -> XlmRobertaTokenizer {
+        let spp = SentencePieceProcessor::load(env!("XLM_ROBERTA_BASE_SENTENCEPIECE")).unwrap();
+        XlmRobertaTokenizer::from(spp)
+    }
+
+    #[test]
+    fn tokenizer_gives_expected_output() {
+        let tokenizer = xlm_roberta_tokenizer();
+        let sent = sentence_from_forms(&["Veruntreute", "die", "AWO", "Spendengeld", "?"]);
+        let pieces = tokenizer.tokenize(sent);
+        assert_eq!(
+            pieces.pieces,
+            array![0, 310, 23451, 107, 6743, 68, 62, 43789, 207126, 49004, 705, 2]
+        );
+    }
+}

--- a/sticker2/testdata/sticker.conf
+++ b/sticker2/testdata/sticker.conf
@@ -1,5 +1,5 @@
 [input]
-word_pieces = "bert-base-german-cased-vocab.txt"
+vocab = "bert-base-german-cased-vocab.txt"
 
 [labeler]
 labels = "sticker.labels"
@@ -13,3 +13,4 @@ encoders = [
 parameters = "epoch-99"
 position_embeddings = "model"
 pretrain_config = "bert_config.json"
+pretrain_type = "bert"

--- a/tests.nix
+++ b/tests.nix
@@ -2,14 +2,22 @@
 
 let
   sources = import ./nix/sources.nix;
+  models = import ./nix/models.nix;
   danieldk = pkgs.callPackage sources.danieldk {};
+  # PyTorch 1.4.0 headers are not compatible with gcc 9. Remove with
+  # the next PyTorch release.
+  stdenv = if pkgs.stdenv.cc.isGNU then pkgs.gcc8Stdenv else pkgs.stdenv;
   crateOverrides = with pkgs; defaultCrateOverrides // {
     hdf5-sys = attr: {
       HDF5_DIR = symlinkJoin { name = "hdf5-join"; paths = [ hdf5.dev hdf5.out ]; };
     };
 
-    sticker2 = attr: {
-      BERT_BASE_GERMAN_CASED_VOCAB = sources.bert-base-german-cased-vocab;
+    sticker2 = attr: models;
+
+    sentencepiece-sys = attr: {
+      nativeBuildInputs = [ pkgconfig ];
+
+      buildInputs = [ (sentencepiece.override (attrs: { inherit stdenv; })) ];
     };
 
     torch-sys = attr: {
@@ -17,11 +25,9 @@ let
     };
   };
   buildRustCrate = pkgs.buildRustCrate.override {
-    defaultCrateOverrides = crateOverrides;
+    inherit stdenv;
 
-    # PyTorch 1.4.0 headers are not compatible with gcc 9. Remove with
-    # the next PyTorch release.
-    stdenv = if pkgs.stdenv.cc.isGNU then pkgs.gcc8Stdenv else pkgs.stdenv;
+    defaultCrateOverrides = crateOverrides;
   };
   cargo_nix = pkgs.callPackage ./nix/Cargo.nix { inherit buildRustCrate; };
 in pkgs.lib.mapAttrsToList (_: drv: drv.build.override {


### PR DESCRIPTION
This follows the approach proposed by Tobias: use sentencepiece as if
it is a subword tokenizer. Overview of changes:

- Introduce the XLMRobertaTokenizer data structure.
- Change the `input.word_pieces` option to `input.vocab`
- Add the `model.pretrain_type` option to distinguish between BERT and
  XLM-RoBERTa models.
- Move Nix model derivations to `nix/models.nix`

I considered performing pre- or post-processing, but it becomes hairy
pretty quickly. E.g. for quotation marks, you have to keep track of
whether they were opening quotations or closing quotations. Some
quotation marks are fused into one token, etc.

---

Note: I haven't been able to really test this yet, since we are using all capable GPUs ;).