### PR TITLE
Add the `load-hdf5` feature for loading models from HDF5

### DIFF
--- a/nix/Cargo.nix
+++ b/nix/Cargo.nix
@@ -3028,7 +3028,7 @@ rec {
           "default" = [ "load-hdf5" ];
           "load-hdf5" = [ "hdf5" ];
         };
-        resolvedDefaultFeatures = [ "default" "hdf5" "load-hdf5" ];
+        resolvedDefaultFeatures = [ "hdf5" "load-hdf5" ];
       };
       "sticker2 0.2.0 (path+file:///home/daniel/git/sticker2/sticker2)" = rec {
         crateName = "sticker2";
@@ -3091,6 +3091,7 @@ rec {
           {
             name = "sticker-transformers";
             packageId = "sticker-transformers 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)";
+            usesDefaultFeatures = false;
           }
           {
             name = "tch";
@@ -3116,8 +3117,10 @@ rec {
           }
         ];
         features = {
+          "default" = [ "load-hdf5" ];
+          "load-hdf5" = [ "sticker-transformers/load-hdf5" ];
         };
-        resolvedDefaultFeatures = [ "model-tests" ];
+        resolvedDefaultFeatures = [ "default" "load-hdf5" "model-tests" ];
       };
       "sticker2-utils 0.2.0 (path+file:///home/daniel/git/sticker2/sticker2-utils)" = rec {
         crateName = "sticker2-utils";
@@ -3171,10 +3174,12 @@ rec {
           {
             name = "sticker-transformers";
             packageId = "sticker-transformers 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)";
+            usesDefaultFeatures = false;
           }
           {
             name = "sticker2";
             packageId = "sticker2 0.2.0 (path+file:///home/daniel/git/sticker2/sticker2)";
+            usesDefaultFeatures = false;
           }
           {
             name = "tch";
@@ -3185,7 +3190,11 @@ rec {
             packageId = "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
-        
+        features = {
+          "default" = [ "load-hdf5" ];
+          "load-hdf5" = [ "sticker-transformers/load-hdf5" "sticker2/load-hdf5" ];
+        };
+        resolvedDefaultFeatures = [ "default" "load-hdf5" ];
       };
       "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = rec {
         crateName = "strsim";

--- a/sticker2-utils/Cargo.toml
+++ b/sticker2-utils/Cargo.toml
@@ -17,8 +17,12 @@ itertools = "0.8"
 ordered-float = { version = "1", features = ["serde"] }
 serde_yaml = "0.8"
 stdinout = "0.4"
-sticker2 = { path = "../sticker2" }
+sticker2 = { path = "../sticker2", default-features = false }
 sticker-encoders = "0.2"
-sticker-transformers = "0.4.0"
+sticker-transformers = { version = "0.4.0", default-features = false }
 tch = "0.1.5"
 threadpool = "1"
+
+[features]
+default = ["load-hdf5"]
+load-hdf5 = ["sticker-transformers/load-hdf5", "sticker2/load-hdf5"]

--- a/sticker2-utils/src/io.rs
+++ b/sticker2-utils/src/io.rs
@@ -76,6 +76,7 @@ impl Model {
     /// In contrast to `load_model`, this does not load the parameters
     /// specified in the configuration file, but the parameters from
     /// the HDF5 file at `hdf5_path`.
+    #[cfg(feature = "load-hdf5")]
     pub fn load_from_hdf5(config_path: &str, hdf5_path: &str, device: Device) -> Model {
         let config = load_config(config_path);
         let encoders = load_encoders(&config);
@@ -94,6 +95,12 @@ impl Model {
             tokenizer,
             vs,
         }
+    }
+
+    #[cfg(not(feature = "load-hdf5"))]
+    pub fn load_from_hdf5(_config_path: &str, _hdf5_path: &str, _device: Device) -> Model {
+        eprintln!("Cannot load HDF5 model: sticker2 was compiled without support for HDF5");
+        std::process::exit(1);
     }
 }
 

--- a/sticker2/Cargo.toml
+++ b/sticker2/Cargo.toml
@@ -24,7 +24,7 @@ sentencepiece = "0.1.3"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sticker-encoders = "0.2"
-sticker-transformers = "0.4.0"
+sticker-transformers = { version = "0.4.1", default-features = false }
 tch = "0.1.5"
 toml = "0.5"
 wordpieces = "0.2"
@@ -34,4 +34,6 @@ approx = "0.3"
 maplit = "1"
 
 [features]
+default = ["load-hdf5"]
+load-hdf5 = ["sticker-transformers/load-hdf5"]
 model-tests = []

--- a/sticker2/src/model/mod.rs
+++ b/sticker2/src/model/mod.rs
@@ -1,9 +1,13 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
+#[cfg(feature = "load-hdf5")]
 use std::path;
 
+#[cfg(feature = "load-hdf5")]
 use failure::Fallible;
+#[cfg(feature = "load-hdf5")]
 use hdf5::File;
+#[cfg(feature = "load-hdf5")]
 use sticker_transformers::hdf5_model::LoadFromHDF5;
 use sticker_transformers::layers::Dropout;
 use sticker_transformers::models::bert::{
@@ -60,6 +64,7 @@ impl BertEmbeddingLayer {
         }
     }
 
+    #[cfg(feature = "load-hdf5")]
     fn load_from_hdf5<'a>(
         vs: impl Borrow<Path<'a>>,
         pretrain_config: &PretrainConfig,
@@ -159,6 +164,7 @@ impl BertModel {
         })
     }
 
+    #[cfg(feature = "load-hdf5")]
     /// Construct a model and load parameters from a pretrained model.
     ///
     /// `layer_dropout` is the probability with which layers should

--- a/tests.nix
+++ b/tests.nix
@@ -33,7 +33,13 @@ let
     defaultCrateOverrides = crateOverrides;
   };
   cargo_nix = pkgs.callPackage ./nix/Cargo.nix { inherit buildRustCrate; };
-in pkgs.lib.mapAttrsToList (_: drv: drv.build.override {
-  features = [ "model-tests" ];
-  runTests = true;
-}) cargo_nix.workspaceMembers
+in with pkgs; lib.flatten (lib.mapAttrsToList (_: drv: [
+  (drv.build.override {
+    features = [ "model-tests" ];
+    runTests = true;
+  })
+  (drv.build.override {
+    features = [ "load-hdf5" "model-tests" ];
+    runTests = true;
+  })
+]) cargo_nix.workspaceMembers)


### PR DESCRIPTION
This features is enabled by default, but can be disabled to support
building sticker2 without a libhdf5 dependency.