### PR TITLE
Update to sticker-encoders 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sticker-encoders"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1051,7 +1051,7 @@ dependencies = [
  "sentencepiece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-encoders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker-transformers 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tch 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1070,7 +1070,7 @@ dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-encoders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker-transformers 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sticker2 0.1.1",
  "tch 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1404,7 +1404,7 @@ dependencies = [
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29f1026ef7b2ded56453d708809e15f148b7f5b6a51e1ee0237964881ab85680"
-"checksum sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b18e8f862bc727afdf90b668aa2128a34fceb2f54fd2d340658583fd544588a4"
+"checksum sticker-encoders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7de7816317232f3b6df4c3cd956504d868ee36914c07550eb701fa8d2a561a7"
 "checksum sticker-transformers 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "062f20ac66cdced0f1b63b4283ece02ff515332cb7808d6047a90405855b6749"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/nix/Cargo.nix
+++ b/nix/Cargo.nix
@@ -3091,12 +3091,12 @@ rec {
         features = {
         };
       };
-    "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)"
+    "sticker-encoders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "sticker-encoders";
-        version = "0.1.4";
+        version = "0.2.0";
         edition = "2018";
-        sha256 = "19488magv0w5cm0d7ljgynrcwkx350hsls5nj3gsy9y75f38z3mi";
+        sha256 = "19v1lp9ah7vhxd87bh0ld7iqx1jda1bdjg2cvyvg6ckj64b7ippp";
         authors = [
           "Daniël de Kok <me@danieldk.eu>"
         ];
@@ -3225,7 +3225,7 @@ rec {
           }
           {
             name = "sticker-encoders";
-            packageId = "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)";
+            packageId = "sticker-encoders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
           }
           {
             name = "sticker-transformers";
@@ -3305,7 +3305,7 @@ rec {
           }
           {
             name = "sticker-encoders";
-            packageId = "sticker-encoders 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)";
+            packageId = "sticker-encoders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
           }
           {
             name = "sticker-transformers";

--- a/sticker2-utils/Cargo.toml
+++ b/sticker2-utils/Cargo.toml
@@ -18,7 +18,7 @@ ordered-float = { version = "1", features = ["serde"] }
 serde_yaml = "0.8"
 stdinout = "0.4"
 sticker2 = { path = "../sticker2" }
-sticker-encoders = "0.1.4"
+sticker-encoders = "0.2"
 sticker-transformers = "0.4.0"
 tch = "0.1.5"
 threadpool = "1"

--- a/sticker2/Cargo.toml
+++ b/sticker2/Cargo.toml
@@ -23,7 +23,7 @@ rand_xorshift = "0.2"
 sentencepiece = "0.1.3"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-sticker-encoders = "0.1.4"
+sticker-encoders = "0.2"
 sticker-transformers = "0.4.0"
 tch = "0.1.5"
 toml = "0.5"

--- a/sticker2/src/config.rs
+++ b/sticker2/src/config.rs
@@ -207,7 +207,10 @@ mod tests {
                     encoders: EncodersConfig(vec![
                         NamedEncoderConfig {
                             name: "dep".to_string(),
-                            encoder: EncoderType::Dependency(DependencyEncoder::RelativePOS)
+                            encoder: EncoderType::Dependency {
+                                encoder: DependencyEncoder::RelativePOS,
+                                root_relation: "root".to_string()
+                            }
                         },
                         NamedEncoderConfig {
                             name: "lemma".to_string(),

--- a/sticker2/src/encoders/config.rs
+++ b/sticker2/src/encoders/config.rs
@@ -25,7 +25,10 @@ impl Deref for EncodersConfig {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum EncoderType {
     /// Encoder for syntactical dependencies.
-    Dependency(DependencyEncoder),
+    Dependency {
+        encoder: DependencyEncoder,
+        root_relation: String,
+    },
 
     /// Lemma encoder using edit trees.
     Lemma(BackoffStrategy),

--- a/sticker2/src/encoders/encoders.rs
+++ b/sticker2/src/encoders/encoders.rs
@@ -136,15 +136,26 @@ impl From<&EncoderType> for Encoder {
     fn from(encoder_type: &EncoderType) -> Self {
         // We start labeling at 2. 0 is reserved for padding, 1 for continuations.
         match encoder_type {
-            EncoderType::Dependency(DependencyEncoder::RelativePOS) => Encoder::RelativePOS(
-                MutableCategoricalEncoder::new(RelativePOSEncoder, Numberer::new(2)).into(),
-            ),
-            EncoderType::Dependency(DependencyEncoder::RelativePosition) => {
-                Encoder::RelativePosition(
-                    MutableCategoricalEncoder::new(RelativePositionEncoder, Numberer::new(2))
-                        .into(),
+            EncoderType::Dependency {
+                encoder: DependencyEncoder::RelativePOS,
+                root_relation,
+            } => Encoder::RelativePOS(
+                MutableCategoricalEncoder::new(
+                    RelativePOSEncoder::new(root_relation),
+                    Numberer::new(2),
                 )
-            }
+                .into(),
+            ),
+            EncoderType::Dependency {
+                encoder: DependencyEncoder::RelativePosition,
+                root_relation,
+            } => Encoder::RelativePosition(
+                MutableCategoricalEncoder::new(
+                    RelativePositionEncoder::new(root_relation),
+                    Numberer::new(2),
+                )
+                .into(),
+            ),
             EncoderType::Lemma(backoff_strategy) => Encoder::Lemma(
                 MutableCategoricalEncoder::new(
                     EditTreeEncoder::new(*backoff_strategy),

--- a/sticker2/testdata/sticker.conf
+++ b/sticker2/testdata/sticker.conf
@@ -4,7 +4,7 @@ vocab = "bert-base-german-cased-vocab.txt"
 [labeler]
 labels = "sticker.labels"
 encoders = [
-  { name = "dep", encoder = { dependency = "relativepos" } },
+  { name = "dep", encoder = { dependency = { encoder = "relativepos", root_relation = "root" } } },
   { name = "lemma", encoder = { lemma = "form" } },
   { name = "pos", encoder = { sequence = "pos" } },
 ]


### PR DESCRIPTION
This makes the root relation configurable for the dependency
encoders. A corresponding configuration option was added. This
changes the configuration format, albeit in a minor way.