### PR TITLE
sticker-{annotate,server}: increase readahead from 10 -> 100

### DIFF
--- a/sticker2-utils/src/subcommands/annotate.rs
+++ b/sticker2-utils/src/subcommands/annotate.rs
@@ -118,7 +118,7 @@ impl StickerApp for AnnotateApp {
                 Arg::with_name(READ_AHEAD)
                     .help("Readahead (number of batches)")
                     .long("readahead")
-                    .default_value("10"),
+                    .default_value("100"),
             )
     }
 

--- a/sticker2-utils/src/subcommands/server.rs
+++ b/sticker2-utils/src/subcommands/server.rs
@@ -113,7 +113,7 @@ impl StickerApp for ServerApp {
                 Arg::with_name(READ_AHEAD)
                     .help("Readahead (number of batches)")
                     .long("readahead")
-                    .default_value("10"),
+                    .default_value("100"),
             )
             .arg(
                 Arg::with_name(THREADS)


### PR DESCRIPTION
Since we use very small batch sizes, a lot is gained by reading ahead
many more batches.