### PR TITLE
Pin nixpkgs to a recent commit on the 20.03 channel

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -55,15 +55,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-unstable",
+        "branch": "nixos-20.03",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "nixos",
         "repo": "nixpkgs-channels",
-        "rev": "7c399a4ee080f33cc500a3fda33af6fccfd617bd",
-        "sha256": "0vqljvz5yrc8i3nj3d5xiiv475yydscckfc9z0hpran9q2rh4md1",
+        "rev": "025deb80b2412e5b7e88ea1de631d1bd65af1840",
+        "sha256": "09mp6vqs0h71g27w004yrz1jxla31ihf18phw69wj61ix74ac4m0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs-channels/archive/7c399a4ee080f33cc500a3fda33af6fccfd617bd.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs-channels/archive/025deb80b2412e5b7e88ea1de631d1bd65af1840.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "xlm-roberta-base-sentencepiece": {

--- a/tests.nix
+++ b/tests.nix
@@ -23,7 +23,7 @@ let
     sentencepiece-sys = attr: {
       nativeBuildInputs = [ pkgconfig ];
 
-      buildInputs = [ (sentencepiece.override (attrs: { inherit stdenv; })) ];
+      buildInputs = [ sentencepiece ];
     };
 
     torch-sys = attr: {


### PR DESCRIPTION
Motivation:

- Channel: Larger set of packages in the binary cache compared pinning
  an arbitrary commit.
- 20.03: Easier to have similar nixpkgs between projects. Release
  channels move much more slowly, so it is more likely that packages
  are shared between builds.