### PR TITLE
Update to sentencepiece 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,9 +1229,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentencepiece"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8c45bded1895d574ff6bca05275a9bbf26406017e4bae73ccfb0b21524052f"
+checksum = "eaa3cf1ed4744a4e6d4188c87c9a52447ee8bd2cd5b692cdaaf0221abd3ae9e6"
 dependencies = [
  "libc",
  "num-derive",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "sentencepiece-sys"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30cc4b55005ef503ea8d68f453919d5f0a0c60cd245d2bc245545ace339101a"
+checksum = "f946d54d13d95f0153948b5693ceca17a51ef25ea025c3e25b232e6572c81230"
 dependencies = [
  "cc",
  "pkg-config",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -55,15 +55,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.03",
+        "branch": "nixos-unstable",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "nixos",
         "repo": "nixpkgs-channels",
-        "rev": "025deb80b2412e5b7e88ea1de631d1bd65af1840",
-        "sha256": "09mp6vqs0h71g27w004yrz1jxla31ihf18phw69wj61ix74ac4m0",
+        "rev": "dc80d7bc4a244120b3d766746c41c0d9c5f81dfa",
+        "sha256": "0dy0mp7alc7m34zxall14x42qx9yjm7b0m6psgmw0lb6j1iy1pla",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs-channels/archive/025deb80b2412e5b7e88ea1de631d1bd65af1840.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs-channels/archive/dc80d7bc4a244120b3d766746c41c0d9c5f81dfa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "xlm-roberta-base-sentencepiece": {

--- a/sticker2/Cargo.toml
+++ b/sticker2/Cargo.toml
@@ -21,7 +21,7 @@ numberer = "0.2"
 ordered-float = "1"
 rand = "0.7"
 rand_xorshift = "0.2"
-sentencepiece = "0.2"
+sentencepiece = "0.3"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sticker-encoders = "0.5.1"


### PR DESCRIPTION
This also requires us to update to nixpkgs-unstable, since the
sentencepiece crate now requires sentencepiece 0.1.90.