### PR TITLE
Make tensorboard support an optional feature

### DIFF
--- a/sticker2-utils/Cargo.toml
+++ b/sticker2-utils/Cargo.toml
@@ -27,10 +27,11 @@ stdinout = "0.4"
 sticker2 = { path = "../sticker2", version = "0.4", default-features = false }
 sticker-encoders = "0.5"
 sticker-transformers = { version = "0.8", default-features = false }
-tfrecord = { version = "0.3", features = ["summary"] }
+tfrecord = { version = "0.3", features = ["summary"], optional = true }
 tch = "0.2.0"
 threadpool = "1"
 
 [features]
-default = ["load-hdf5"]
+default = ["load-hdf5", "tensorboard"]
 load-hdf5 = ["sticker-transformers/load-hdf5", "sticker2/load-hdf5"]
+tensorboard = ["tfrecord"]

--- a/sticker2-utils/src/io.rs
+++ b/sticker2-utils/src/io.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
 use std::fs::File;
-use std::io::BufWriter;
 
 use anyhow::{Context, Result};
 use sticker2::config::{Config, PretrainConfig, TomlRead};
@@ -9,7 +7,6 @@ use sticker2::input::Tokenize;
 use sticker2::model::bert::BertModel;
 use tch::nn::VarStore;
 use tch::Device;
-use tfrecord::{EventWriter, EventWriterInit};
 
 /// Wrapper around different parts of a model.
 pub struct Model {
@@ -149,29 +146,4 @@ pub fn load_tokenizer(config: &Config) -> Result<Box<dyn Tokenize>> {
     config
         .tokenizer()
         .context("Cannot read tokenizer vocabulary")
-}
-
-pub struct TensorBoardWriter {
-    writer: Option<RefCell<EventWriter<BufWriter<File>>>>,
-}
-
-impl TensorBoardWriter {
-    pub fn new(prefix: impl AsRef<str>) -> Result<Self> {
-        let writer = EventWriterInit::default().from_prefix(prefix, None)?;
-        Ok(TensorBoardWriter {
-            writer: Some(RefCell::new(writer)),
-        })
-    }
-
-    pub fn noop() -> Self {
-        TensorBoardWriter { writer: None }
-    }
-
-    pub fn write_scalar(&self, tag: &str, step: i64, value: f32) -> Result<()> {
-        if let Some(ref writer) = self.writer {
-            writer.borrow_mut().write_scalar(tag, step, value)?;
-        }
-
-        Ok(())
-    }
 }

--- a/sticker2-utils/src/main.rs
+++ b/sticker2-utils/src/main.rs
@@ -11,6 +11,8 @@ pub mod save;
 
 pub mod sent_proc;
 
+pub mod summary;
+
 mod subcommands;
 
 pub mod traits;

--- a/sticker2-utils/src/summary/mod.rs
+++ b/sticker2-utils/src/summary/mod.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+
+pub trait SummaryWriter {
+    fn write_scalar(&self, tag: &str, step: i64, value: f32) -> Result<()>;
+}
+
+pub struct NoopWriter;
+
+impl SummaryWriter for NoopWriter {
+    fn write_scalar(&self, _tag: &str, _step: i64, _value: f32) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct SummaryOption;
+
+#[cfg(feature = "tensorboard")]
+pub(crate) mod tensorboard;
+#[cfg(feature = "tensorboard")]
+mod option_impl {
+    use anyhow::Result;
+    use clap::{App, Arg, ArgMatches};
+
+    use super::{tensorboard, NoopWriter, SummaryOption, SummaryWriter};
+    use crate::traits::StickerOption;
+
+    const LOG_PREFIX: &str = "LOG_PREFIX";
+
+    impl StickerOption for SummaryOption {
+        type Value = Box<dyn SummaryWriter>;
+
+        fn add_to_app(app: App<'static, 'static>) -> App<'static, 'static> {
+            app.arg(
+                Arg::with_name(LOG_PREFIX)
+                    .long("log-prefix")
+                    .value_name("PREFIX")
+                    .takes_value(true)
+                    .help("Prefix for Tensorboard logs"),
+            )
+        }
+
+        fn parse(matches: &ArgMatches) -> Result<Self::Value> {
+            Ok(match matches.value_of(LOG_PREFIX) {
+                Some(prefix) => {
+                    Box::new(tensorboard::TensorBoardWriter::new(prefix)?) as Box<dyn SummaryWriter>
+                }
+                None => Box::new(NoopWriter),
+            })
+        }
+    }
+}
+
+#[cfg(not(feature = "tensorboard"))]
+mod option_impl {
+    use anyhow::Result;
+    use clap::{App, ArgMatches};
+
+    use super::{NoopWriter, SummaryOption, SummaryWriter};
+    use crate::traits::StickerOption;
+
+    impl StickerOption for SummaryOption {
+        type Value = Box<dyn SummaryWriter>;
+
+        fn add_to_app(app: App<'static, 'static>) -> App<'static, 'static> {
+            app
+        }
+
+        fn parse(_matches: &ArgMatches) -> Result<Self::Value> {
+            Ok(Box::new(NoopWriter))
+        }
+    }
+}

--- a/sticker2-utils/src/summary/tensorboard.rs
+++ b/sticker2-utils/src/summary/tensorboard.rs
@@ -1,0 +1,27 @@
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::BufWriter;
+
+use anyhow::Result;
+use tfrecord::{EventWriter, EventWriterInit};
+
+use super::SummaryWriter;
+
+pub struct TensorBoardWriter {
+    writer: RefCell<EventWriter<BufWriter<File>>>,
+}
+
+impl TensorBoardWriter {
+    pub fn new(prefix: impl AsRef<str>) -> Result<Self> {
+        let writer = EventWriterInit::default().from_prefix(prefix, None)?;
+        Ok(TensorBoardWriter {
+            writer: RefCell::new(writer),
+        })
+    }
+}
+
+impl SummaryWriter for TensorBoardWriter {
+    fn write_scalar(&self, tag: &str, step: i64, value: f32) -> Result<()> {
+        Ok(self.writer.borrow_mut().write_scalar(tag, step, value)?)
+    }
+}

--- a/sticker2-utils/src/traits.rs
+++ b/sticker2-utils/src/traits.rs
@@ -16,3 +16,11 @@ where
 
     fn run(&self) -> Result<()>;
 }
+
+pub trait StickerOption {
+    type Value;
+
+    fn add_to_app(app: App<'static, 'static>) -> App<'static, 'static>;
+
+    fn parse(matches: &ArgMatches) -> Result<Self::Value>;
+}

--- a/tests.nix
+++ b/tests.nix
@@ -48,7 +48,7 @@ in with pkgs; lib.flatten (lib.mapAttrsToList (_: drv: [
     runTests = true;
   })
   (drv.build.override {
-    features = [ "load-hdf5" "model-tests" ];
+    features = [ "load-hdf5" "model-tests" "tensorboard" ];
     runTests = true;
   })
 ]) cargoNix.workspaceMembers)


### PR DESCRIPTION
This change adds the `tensorboard` feature, which is enabled by
default. However, since TensorBoard support adds *a lot* transitive
dependencies, this change makes it possible to disable it in builds.