### PR TITLE
nix: update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -55,22 +55,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "nixos",
         "repo": "nixpkgs-channels",
-        "rev": "dc80d7bc4a244120b3d766746c41c0d9c5f81dfa",
-        "sha256": "0dy0mp7alc7m34zxall14x42qx9yjm7b0m6psgmw0lb6j1iy1pla",
+        "rev": "61525137fd1002f6f2a5eb0ea27d480713362cd5",
+        "sha256": "1gzwz9jvfcf0is6zma7qlgszkngfb2aa4kam0nhs0qnwb4nqn7mg",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs-channels/archive/dc80d7bc4a244120b3d766746c41c0d9c5f81dfa.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "sticker": {
-        "branch": "master",
-        "description": "Nix package set for sticker, models, and bindings",
-        "homepage": null,
-        "owner": "stickeritis",
-        "repo": "nix-packages",
-        "rev": "3688f0cef0d709273188a64b2af8c8e34f066f10",
-        "sha256": "0pqdfrx6n20d6g15l95qvrjy756rq1mcarf4i58bga1gkzmb1hip",
-        "type": "tarball",
-        "url": "https://github.com/stickeritis/nix-packages/archive/3688f0cef0d709273188a64b2af8c8e34f066f10.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs-channels/archive/61525137fd1002f6f2a5eb0ea27d480713362cd5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "xlm-roberta-base-sentencepiece": {

--- a/shell.nix
+++ b/shell.nix
@@ -4,10 +4,14 @@
 let
   sources = import ./nix/sources.nix;
   models = import ./nix/models.nix;
-  nixpkgs = import sources.nixpkgs {};
-  sticker = nixpkgs.callPackage sources.sticker {};
+  nixpkgs = import sources.nixpkgs {
+   config = {
+      allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+        "libtorch"
+      ];
+    };
+  };
   mozilla = nixpkgs.callPackage "${sources.mozilla}/package-set.nix" {};
-  libtorch = sticker.libtorch.v1_6_0;
 in with nixpkgs; mkShell (models // {
   nativeBuildInputs = [
     mozilla.latest.rustChannels.stable.rust
@@ -18,11 +22,16 @@ in with nixpkgs; mkShell (models // {
     curl
     openssl
     sentencepiece
-    libtorch
   ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
   # Unless we use pkg-config, the hdf5-sys build script does not like
   # it if libraries and includes are in different directories.
-  HDF5_DIR = symlinkJoin { name = "hdf5-join"; paths = [ hdf5.dev hdf5.out ]; };
+  HDF5_DIR = symlinkJoin {
+    name = "hdf5-join";
+    paths = [ hdf5.dev hdf5.out ];
+  };
 
-  LIBTORCH = "${libtorch.dev}";
+  LIBTORCH = symlinkJoin {
+    name = "torch-join";
+    paths = [ libtorch-bin.dev libtorch-bin.out ];
+  };
 })


### PR DESCRIPTION
This allows us to switch to the new libtorch-bin derivation in nixpkgs.

Also use join the `libtorch-bin.{dev,out}` derivations for the
`LIBTORCH` environment variable in `shell.nix`. As a result of this
change, the build script of the `tch` can correctly detect if we are
using a libtorch with CUDA support and will correctly link
`libtorch_cuda`. This leads to bigger closures, but that is not a
problem here, since `shell.nix` is only used for development.