### PR TITLE
Do not use anyhow in sticker2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,6 @@ dependencies = [
 name = "sticker2"
 version = "0.4.0"
 dependencies = [
- "anyhow",
  "approx",
  "conllu",
  "criterion",

--- a/sticker2-utils/src/subcommands/distill.rs
+++ b/sticker2-utils/src/subcommands/distill.rs
@@ -11,6 +11,7 @@ use ordered_float::NotNan;
 use sticker2::config::Config;
 use sticker2::dataset::{ConlluDataSet, DataSet, SequenceLength};
 use sticker2::encoders::Encoders;
+use sticker2::error::StickerError;
 use sticker2::input::Tokenize;
 use sticker2::lr::{ExponentialDecay, LearningRateSchedule};
 use sticker2::model::bert::{BertModel, FreezeLayers};
@@ -177,8 +178,8 @@ impl DistillApp {
     fn train_steps(
         &self,
         progress: &ProgressBar,
-        teacher_batches: impl Iterator<Item = Result<Tensors>>,
-        student_batches: impl Iterator<Item = Result<Tensors>>,
+        teacher_batches: impl Iterator<Item = Result<Tensors, StickerError>>,
+        student_batches: impl Iterator<Item = Result<Tensors, StickerError>>,
         global_step: &mut usize,
         optimizer: &mut AdamW,
         teacher: &BertModel,

--- a/sticker2/Cargo.toml
+++ b/sticker2/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/stickeritis/sticker.git"
 license-file = "../LICENSE.md"
 
 [dependencies]
-anyhow = "1"
 conllu = "0.5"
 edit_tree = "0.1.1"
 hdf5 = { version = "0.6", optional = true }

--- a/sticker2/src/encoders/mod.rs
+++ b/sticker2/src/encoders/mod.rs
@@ -5,4 +5,4 @@ pub use config::{DependencyEncoder, EncoderType, EncodersConfig, NamedEncoderCon
 
 #[allow(clippy::module_inception)]
 mod encoders;
-pub use encoders::{Encoder, Encoders, NamedEncoder};
+pub use encoders::{DecoderError, Encoder, EncoderError, Encoders, NamedEncoder};

--- a/sticker2/src/error.rs
+++ b/sticker2/src/error.rs
@@ -1,0 +1,48 @@
+use std::io;
+
+use ndarray::ShapeError;
+use sticker_transformers::models::bert::BertError;
+use thiserror::Error;
+
+use crate::encoders::{DecoderError, EncoderError};
+
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum StickerError {
+    #[error(transparent)]
+    BertError(#[from] BertError),
+
+    #[error(transparent)]
+    ConlluIOError(#[from] conllu::IOError),
+
+    #[error(transparent)]
+    DecoderError(#[from] DecoderError),
+
+    #[error(transparent)]
+    EncoderError(#[from] EncoderError),
+
+    #[cfg(feature = "load-hdf5")]
+    #[error(transparent)]
+    HDF5Error(#[from] hdf5::Error),
+
+    #[error(transparent)]
+    IOError(#[from] io::Error),
+
+    #[error("{0}: {1}")]
+    JSonSerialization(String, serde_json::Error),
+
+    #[error("Cannot relativize path: {0}")]
+    RelativizePathError(String),
+
+    #[error(transparent)]
+    SentencePieceError(#[from] sentencepiece::SentencePieceError),
+
+    #[error(transparent)]
+    ShapeError(#[from] ShapeError),
+
+    #[error(transparent)]
+    TOMLDeserializationError(#[from] toml::de::Error),
+
+    #[error(transparent)]
+    WordPiecesError(#[from] wordpieces::WordPiecesError),
+}

--- a/sticker2/src/lib.rs
+++ b/sticker2/src/lib.rs
@@ -2,6 +2,8 @@ pub mod config;
 
 pub mod dataset;
 
+pub mod error;
+
 pub mod encoders;
 
 pub mod graph;

--- a/sticker2/src/model/bert.rs
+++ b/sticker2/src/model/bert.rs
@@ -4,8 +4,6 @@ use std::collections::HashMap;
 use std::path;
 
 #[cfg(feature = "load-hdf5")]
-use anyhow::Error;
-#[cfg(feature = "load-hdf5")]
 use hdf5::File;
 #[cfg(feature = "load-hdf5")]
 use sticker_transformers::hdf5_model::LoadFromHDF5;
@@ -22,6 +20,7 @@ use tch::{self, Tensor};
 
 use crate::config::{PositionEmbeddings, PretrainConfig};
 use crate::encoders::Encoders;
+use crate::error::StickerError;
 use crate::model::seq_classifiers::{SequenceClassifiers, SequenceClassifiersLoss};
 
 pub trait PretrainBertConfig {
@@ -91,7 +90,7 @@ impl BertEmbeddingLayer {
         vs: impl Borrow<Path<'a>>,
         pretrain_config: &PretrainConfig,
         pretrained_file: &File,
-    ) -> Result<BertEmbeddingLayer, Error> {
+    ) -> Result<BertEmbeddingLayer, StickerError> {
         let vs = vs.borrow();
 
         let embeddings = match pretrain_config {
@@ -162,7 +161,7 @@ impl Encoder {
         vs: impl Borrow<Path<'a>>,
         pretrain_config: &PretrainConfig,
         pretrained_file: &File,
-    ) -> Result<Encoder, Error> {
+    ) -> Result<Encoder, BertError> {
         let vs = vs.borrow();
 
         let encoder = match pretrain_config {
@@ -254,7 +253,7 @@ impl BertModel {
         hdf_path: impl AsRef<path::Path>,
         encoders: &Encoders,
         layers_dropout: f64,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, StickerError> {
         let vs = vs.borrow();
 
         let pretrained_file = File::open(hdf_path)?;

--- a/sticker2/src/tagger/mod.rs
+++ b/sticker2/src/tagger/mod.rs
@@ -2,12 +2,12 @@ use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use anyhow::Error;
 use ndarray::{Array1, ArrayD, Axis};
 use sticker_encoders::{EncodingProb, SentenceDecoder};
 use tch::Device;
 
 use crate::encoders::Encoders;
+use crate::error::StickerError;
 use crate::input::SentenceWithPieces;
 use crate::model::bert::BertModel;
 use crate::tensor::{NoLabels, TensorBuilder, Tensors};
@@ -34,7 +34,7 @@ impl Tagger {
     pub fn tag_sentences(
         &self,
         sentences: &mut [impl BorrowMut<SentenceWithPieces>],
-    ) -> Result<(), Error> {
+    ) -> Result<(), StickerError> {
         let top_k_numeric = self.top_k_numeric_(sentences)?;
 
         for (top_k, sentence) in top_k_numeric.into_iter().zip(sentences.iter_mut()) {
@@ -55,7 +55,7 @@ impl Tagger {
     fn prepare_batch(
         &self,
         sentences: &[impl Borrow<SentenceWithPieces>],
-    ) -> Result<Tensors, Error> {
+    ) -> Result<Tensors, StickerError> {
         let max_seq_len = sentences
             .iter()
             .map(|sentence| sentence.borrow().pieces.len())
@@ -87,7 +87,7 @@ impl Tagger {
     fn top_k_numeric_<'a, S>(
         &self,
         sentences: &'a [S],
-    ) -> Result<Vec<HashMap<String, Vec<Vec<EncodingProb<usize>>>>>, Error>
+    ) -> Result<Vec<HashMap<String, Vec<Vec<EncodingProb<usize>>>>>, StickerError>
     where
         S: Borrow<SentenceWithPieces>,
     {


### PR DESCRIPTION
sticker2 is a library crate and should use concrete error types. The
new `StickerError` type mostly wraps existing errors transparently,
this may be refined in the future to provide more context.