### PR TITLE
Add support for mixed-precision training

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "sticker-transformers"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "553e85da263b780774765f9b53d02ae41d0844f616b36aef9a964edad791cb86"
+checksum = "d1306ce4e59f67fa4959c28447c3629a8e3121ea15ac8ed1879c43ce1afac944"
 dependencies = [
  "hdf5",
  "serde",
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "tch"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6023f32ccd1eece94b8f582bfb5101842064aecc70850d12966ada7bb3838407"
+checksum = "57756d8b38ed254fbb9ed7cf47fdd0eb93ffe4d1aa927fd5ffa6b019d0fa4efd"
 dependencies = [
  "half",
  "lazy_static",
@@ -2204,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "torch-sys"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9880d9b8799be31098ebd042e8ef57341434c63fe580754e07e8dd43bf8272c6"
+checksum = "69bad0036396fded468d8f6ea3105b99282dbb65d5da498f65c65e0816738417"
 dependencies = [
  "cc",
  "cmake",

--- a/sticker2-utils/Cargo.toml
+++ b/sticker2-utils/Cargo.toml
@@ -28,7 +28,7 @@ sticker2 = { path = "../sticker2", version = "0.4", default-features = false }
 sticker-encoders = "0.5"
 sticker-transformers = { version = "0.8", default-features = false }
 tfrecord = { version = "0.3", features = ["summary"], optional = true }
-tch = "0.2.0"
+tch = "0.2.1"
 threadpool = "1"
 
 [features]

--- a/sticker2-utils/src/util.rs
+++ b/sticker2-utils/src/util.rs
@@ -21,3 +21,21 @@ pub fn count_conllu_sentences(buf_read: impl BufRead) -> Result<usize> {
 extern "C" fn mkl_serv_intel_cpu_true() -> c_int {
     1
 }
+
+/// Runs a closure with autocast.
+///
+/// This function runs a closure with `autocast` if enabled
+/// is set to `true`. Otherwise, the closure is run without
+/// autocast *iff* the calling function is **not** autocast.
+///
+/// This function can be used to avoid autocasting overhead.
+pub fn autocast_or_preserve<F, T>(enabled: bool, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if enabled {
+        tch::autocast(true, f)
+    } else {
+        f()
+    }
+}

--- a/sticker2/Cargo.toml
+++ b/sticker2/Cargo.toml
@@ -24,8 +24,8 @@ sentencepiece = "0.4"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sticker-encoders = "0.5.1"
-sticker-transformers = { version = "0.8", default-features = false }
-tch = "0.2.0"
+sticker-transformers = { version = "0.8.1", default-features = false }
+tch = "0.2.1"
 thiserror = "1"
 toml = "0.5"
 wordpieces = "0.4"

--- a/sticker2/src/optimizers/grad.rs
+++ b/sticker2/src/optimizers/grad.rs
@@ -1,0 +1,16 @@
+use tch::nn::VarStore;
+
+pub trait ZeroGrad {
+    /// Zero out gradients.
+    fn zero_grad(&self);
+}
+
+impl ZeroGrad for VarStore {
+    fn zero_grad(&self) {
+        for (_, mut tensor) in self.variables() {
+            if tensor.requires_grad() {
+                tensor.zero_grad()
+            }
+        }
+    }
+}

--- a/sticker2/src/optimizers/grad_scale.rs
+++ b/sticker2/src/optimizers/grad_scale.rs
@@ -1,0 +1,137 @@
+use tch::nn::VarStore;
+use tch::{Kind, Tensor};
+
+use super::{Optimizer, ZeroGrad};
+
+pub struct GradScaler<O> {
+    enabled: bool,
+    growth_factor: f64,
+    backoff_factor: f64,
+    growth_interval: i64,
+
+    optimizer: O,
+
+    found_inf: Tensor,
+    growth_tracker: Tensor,
+    scale: Tensor,
+}
+
+impl<O> GradScaler<O>
+where
+    O: Optimizer,
+{
+    fn new(
+        enabled: bool,
+        optimizer: O,
+        init_scale: f64,
+        growth_factor: f64,
+        backoff_factor: f64,
+        growth_interval: i64,
+    ) -> Self {
+        let device = optimizer.var_store().device();
+
+        GradScaler {
+            enabled,
+            growth_factor,
+            backoff_factor,
+            growth_interval,
+
+            optimizer,
+
+            found_inf: Tensor::full(&[1], 0.0, (Kind::Float, device)),
+            growth_tracker: Tensor::full(&[1], 0, (Kind::Int, device)),
+            scale: Tensor::full(&[1], init_scale, (Kind::Float, device)),
+        }
+    }
+
+    pub fn new_with_defaults(enabled: bool, optimizer: O) -> Self {
+        GradScaler::new(enabled, optimizer, 2f64.powi(16), 2., 0.5, 2000)
+    }
+
+    pub fn current_scale(&self) -> f32 {
+        Vec::<f32>::from(&self.scale)[0]
+    }
+
+    pub fn optimizer(&self) -> &O {
+        &self.optimizer
+    }
+
+    pub fn optimizer_mut(&mut self) -> &mut O {
+        &mut self.optimizer
+    }
+
+    pub fn scale(&mut self, t: &Tensor) -> Tensor {
+        if !self.enabled {
+            t.shallow_clone()
+        } else {
+            t * &self.scale
+        }
+    }
+
+    pub fn update(&mut self) {
+        if !self.enabled {
+            return;
+        };
+
+        self.scale = Tensor::internal_amp_update_scale(
+            &self.growth_tracker,
+            &self.scale,
+            &self.found_inf,
+            self.growth_factor,
+            self.backoff_factor,
+            self.growth_interval,
+        );
+
+        // Clear infinity found status.
+        self.found_inf = self.found_inf.zeros_like();
+    }
+}
+
+impl<O> Optimizer for GradScaler<O>
+where
+    O: Optimizer,
+{
+    type Config = O::Config;
+
+    fn backward_step<F>(&mut self, loss: &Tensor, config_fun: F)
+    where
+        F: Fn(&str) -> Self::Config,
+    {
+        self.var_store().zero_grad();
+        self.scale(loss).backward();
+        tch::no_grad(|| self.step(config_fun));
+        self.update();
+    }
+
+    fn step<F>(&mut self, config_fun: F)
+    where
+        F: Fn(&str) -> Self::Config,
+    {
+        if !self.enabled {
+            return self.optimizer.step(config_fun);
+        }
+
+        let inv_scale = self.scale.reciprocal().to_kind(Kind::Float);
+
+        for (_, tensor) in self.optimizer.var_store().variables() {
+            if !tensor.grad().defined() {
+                continue;
+            }
+
+            tensor
+                .grad()
+                .internal_amp_non_finite_check_and_unscale(&mut self.found_inf, &inv_scale);
+        }
+
+        let found_inf = Vec::<f32>::from(&self.found_inf) == [1.0];
+
+        // Only step when there are no infinite gradients.
+        if !found_inf {
+            self.optimizer.step(config_fun)
+        }
+    }
+
+    fn var_store(&self) -> &VarStore {
+        self.optimizer.var_store()
+    }
+}

--- a/sticker2/src/optimizers/mod.rs
+++ b/sticker2/src/optimizers/mod.rs
@@ -1,2 +1,42 @@
+use tch::nn::VarStore;
+use tch::Tensor;
+
 mod adamw;
 pub use adamw::{AdamW, AdamWConfig};
+
+mod grad;
+pub use grad::ZeroGrad;
+
+mod grad_scale;
+pub use grad_scale::GradScaler;
+
+pub trait Optimizer {
+    type Config;
+
+    /// Perform a backward step on the given loss.
+    ///
+    /// The provided configuration function is given the full name of
+    /// the variable and should return the Adam configuration. This
+    /// makes it possible to use different Adam hyper parameters for
+    /// different parts of a model.
+    fn backward_step<F>(&mut self, loss: &Tensor, config_fun: F)
+    where
+        F: Fn(&str) -> Self::Config;
+
+    /// Perform an update step.
+    ///
+    /// The provided configuration function is given the full name of
+    /// the variable and should return the Adam configuration. This
+    /// makes it possible to use different Adam hyper parameters for
+    /// different parts of a model.
+    ///
+    /// It is generally recommended to use `backward_step`, since it
+    /// computes the gradients and performs any loss scaling (if
+    /// necessary).
+    fn step<F>(&mut self, config_fun: F)
+    where
+        F: Fn(&str) -> Self::Config;
+
+    /// Get the variable store used by the optimizer.
+    fn var_store(&self) -> &VarStore;
+}


### PR DESCRIPTION
This change adds the `--mixed-precision` option to `sticker finetune`
and `sticker distill`. This will speed up training and reduce memory
use on NVIDIA GPUs with Tensor Cores.